### PR TITLE
Remove -std=c++11 flag

### DIFF
--- a/include/ivi-logging-config.h.in
+++ b/include/ivi-logging-config.h.in
@@ -37,5 +37,9 @@ public:
 typedef LogContextT<
 	TypeSet<@CONSOLE_OR_NULL@, @DLT_OR_NULL@>, TypeSet<@CONSOLE_OR_NULL@::LogDataType, @DLT_OR_NULL@::LogDataType> > DefaultLogContext;
 
+/// Use that type to output to the DLT if DLT is enabled, or to 
+typedef LogContextT<
+	TypeSet<@DLT_OR_NULL@>, TypeSet<@DLT_OR_NULL@::LogDataType> > DltIfEnabledLogContext;
+
 }
 

--- a/ivi-logging.pc.in
+++ b/ivi-logging.pc.in
@@ -8,4 +8,4 @@ Description: IVI Logging
 Version: @VERSION@
 Requires: @ADDITIONAL_PKGCONFIG_DEPENDENCIES@
 Libs: -livi-logging @DEVELOPMENT_LIBRARY_PATH@ -L${libdir}
-Cflags: -std=c++11 @ADDITIONAL_PKGCONFIG_CFLAGS@ @DEVELOPMENT_INCLUDE_PATH@ -I${includedir}/ivi-logging
+Cflags: @ADDITIONAL_PKGCONFIG_CFLAGS@ @DEVELOPMENT_INCLUDE_PATH@ -I${includedir}/ivi-logging


### PR DESCRIPTION
The Cflags in pkgconfig file is also used for C files in mixed C/C++ projects. It is not failing those builds, but does generate a lot of warnings from gcc. Also, if it is not strictly necessary, I guess this project should not force using projects to use C++11 unecessarily.