### PR TITLE
Coverity build fixes

### DIFF
--- a/include/ivi-logging-common.h
+++ b/include/ivi-logging-common.h
@@ -169,18 +169,4 @@ __attribute__ ((deprecated)) typedef LogData LogDataCommon;
 
 std::string getStackTrace(unsigned int max_frames = 63);
 
-/// TODO : check if that template method is really inlined by GCC
-template<const char* s1, const char* s2, size_t SIZE1 = strlen(s1), size_t SIZE2 = strlen(s2)>
-static const char* concatenate() {
-    static char s[SIZE1 + SIZE2 + 1];
-    for (size_t i = 0; i < SIZE1; i++)
-        s[i] = s1[i];
-    for (size_t i = 0; i < SIZE2; i++)
-        s[SIZE1 + i] = s2[i];
-//    memcpy(s, s1, SIZE1);
-//    memcpy(s + SIZE1 , s2, SIZE2);
-    s[SIZE1 + SIZE2] = 0;
-    return s;
-}
-
 }

--- a/include/ivi-logging-console.h
+++ b/include/ivi-logging-console.h
@@ -3,6 +3,7 @@
 #include "ivi-logging-common.h"
 #include "stdio.h"
 #include <mutex>
+#include <string>
 #include "ivi-logging-utils.h"
 
 namespace logging {
@@ -396,16 +397,16 @@ public:
         if ( !m_context->isColorsEnabled() )
             return;
 
-        const char* s = ANSI_COLOR_OFF;
+        std::string s = ANSI_COLOR_OFF;
         switch (m_data->getLogLevel()) {
         case LogLevel::Warning : s = ANSI_COLOR_MAGENTA ; break;
         case LogLevel::Error :
-        case LogLevel::Fatal: s = concatenate<ANSI_COLOR_RED, ANSI_COLOR_BRIGHT>(); break;
+        case LogLevel::Fatal : s = std::string(ANSI_COLOR_RED) + std::string(ANSI_COLOR_BRIGHT); break;
         case LogLevel::Verbose : s = ANSI_COLOR_GREEN; break;
         default: s = ANSI_COLOR_OFF; break;
         }
         *this << s;
-        m_invisibleCharacterCount += strlen(s);
+        m_invisibleCharacterCount += s.length();
     }
 
     void writeFooterColor() {
@@ -416,9 +417,9 @@ public:
         if ( !m_context->isColorsEnabled() )
             return;
 
-        auto s = concatenate<ANSI_COLOR_OFF, ANSI_RESET_BRIGHT>();
+        auto s = std::string(ANSI_COLOR_OFF) + std::string(ANSI_RESET_BRIGHT);
         *this << s;
-        m_invisibleCharacterCount += strlen(s);
+        m_invisibleCharacterCount += s.length();
     }
 
 	int m_invisibleCharacterCount = 0;

--- a/include/ivi-logging-utils.h
+++ b/include/ivi-logging-utils.h
@@ -105,20 +105,6 @@ public:
 			return m_dynamicData->size();
 	}
 
-	/**
-	 * Reserve space for a block of the given size and return the position of the block
-	 */
-	size_t skip(size_t length) {
-		auto returnValue = size();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvla"
-		char dummyData[length];
-#pragma GCC diagnostic pop
-		memset(dummyData, 0, length);
-		append( dummyData, sizeof(dummyData) );
-		return returnValue;
-	}
-
 	std::string toString() const {
 		return byteArrayToString( getData(), size() );
 	}


### PR DESCRIPTION
Some fixes needed to just get building projects, that #include ivi-logging headers, with Coverity to work.

If you think performance is an issue with the string literal concatenation, perhaps it would be better to use ByteArray than std::string. Or maybe just have string literals declared at the top for the combinations used (i.e. add a ANSI_COLOR_RED_BRIGHT). But... premature optimization? ;)