### PR TITLE
Build with -pedantic -Wextra without any warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
 	set(CONSOLE_OR_NULL NullLogContext)
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -pedantic -Wextra")
 
 include_directories(
 	include

--- a/examples/basic/exampleLoggingMain.cpp
+++ b/examples/basic/exampleLoggingMain.cpp
@@ -49,23 +49,23 @@ struct MySubClass : MyClass {
 
 struct MyClassWithImportedContext {
 
-    // Define the log context to be used for that class. This overrides any default context which might have previously be set
-    LOG_SET_CLASS_CONTEXT(anotherContext);
+	// Define the log context to be used for that class. This overrides any default context which might have previously be set
+	LOG_SET_CLASS_CONTEXT(anotherContext);
 
-    void doSomething() {
-        log_debug() << "We are doing something. Imported context"; // This log uses the class log context
-    }
+	void doSomething() {
+		log_debug() << "We are doing something. Imported context"; // This log uses the class log context
+	}
 
 };
 
 struct SecondClassWithImportedContext {
 
-    // Define the log context to be used for that class. This overrides any default context which might have previously be set
-    LOG_SET_CLASS_CONTEXT(anotherContext);
+	// Define the log context to be used for that class. This overrides any default context which might have previously be set
+	LOG_SET_CLASS_CONTEXT(anotherContext);
 
-    void doSomething() {
-        log_debug() << "We are doing something. Imported context"; // This log uses the class log context
-    }
+	void doSomething() {
+		log_debug() << "We are doing something. Imported context"; // This log uses the class log context
+	}
 
 };
 
@@ -86,7 +86,7 @@ int generateDataForLogging() {
 }
 
 
-int main(int argc, const char** argv) {
+int main(int, const char**) {
 
 	log_debug().writeFormatted("This log is using a format string, similar to the printf syntax. This is an int : %i", 345);
 	log_error().writeFormatted("Another way to use the printf variant %i", 7345).writeFormatted(". Done");
@@ -103,11 +103,11 @@ int main(int argc, const char** argv) {
 	o.doSomething();
 	o.doSomethingElse();
 
-    MyClassWithImportedContext o2;
-    o2.doSomething();
+	MyClassWithImportedContext o2;
+	o2.doSomething();
 
-    SecondClassWithImportedContext o3;
-    o3.doSomething();
+	SecondClassWithImportedContext o3;
+	o3.doSomething();
 
 	std::string stdString = "That is a std::string";
 	log_error().write("Values can be passed at once to the write method. ", stdString, " / " , 1234);
@@ -135,18 +135,17 @@ int main(int argc, const char** argv) {
 	log_info() << "A log with std::ends" << std::ends;
 	log_info() << "A log with std::flush" << std::flush;
 
-    static const int DURATION = 1000;
+	static const int DURATION = 1000;
 
-    log_info() << "Waiting " << DURATION << " seconds";
+	log_info() << "Waiting " << DURATION << " seconds";
 
-    for(int i = DURATION ; i>0 ; i--) {
-        log_info() << i << " seconds before termination";
-        sleep(1);
-    }
+	for(int i = DURATION ; i>0 ; i--) {
+		log_info() << i << " seconds before termination";
+		sleep(1);
+	}
 
 	disableConsoleLogging();
 	log_error() << "This log should not visible in the console";
 
 	log_info() << "We are done. Bye";
-
 }

--- a/examples/file/exampleLoggingFile.cpp
+++ b/examples/file/exampleLoggingFile.cpp
@@ -8,10 +8,9 @@ LOG_DECLARE_DEFAULT_CONTEXT(mainContext, "MAIN", "This is a description of that 
 
 static constexpr const char* FILE_PATH = "/tmp/ivi-logging-test.txt";
 
-int main(int argc, const char** argv) {
-
-    logging::FileLogContext::setFilePath(FILE_PATH);
-    log_info() << "This log should be written to a file as well : " << FILE_PATH;
+int main(int, const char**) {
+	logging::FileLogContext::setFilePath(FILE_PATH);
+	log_info() << "This log should be written to a file as well : " << FILE_PATH;
 	return 0;
 
 }

--- a/examples/multithreaded/exampleLoggingMultithreaded.cpp
+++ b/examples/multithreaded/exampleLoggingMultithreaded.cpp
@@ -28,10 +28,10 @@ void thread2() {
 	loop(threadName);
 }
 
-int main(int argc, const char** argv) {
+int main(int, char **) {
 	log_debug() << "Hello from main thread";
 	std::thread t1(thread1);
 	std::thread t2(thread2);
-    t1.join();
-    t2.join();
+	t1.join();
+	t2.join();
 }

--- a/include/ivi-logging-file.h
+++ b/include/ivi-logging-file.h
@@ -16,7 +16,7 @@ class FileLogContext : public StreamLogContextAbstract {
 public:
 	typedef FileLogData LogDataType;
 
-    FILE* getFile(logging::StreamLogData& data) override {
+    FILE* getFile(logging::StreamLogData&) override {
         return getFileStatic();
     }
 

--- a/include/ivi-logging-null.h
+++ b/include/ivi-logging-null.h
@@ -30,7 +30,7 @@ public:
 	}
 
     template<typename ... Args>
-    void writeFormatted(const char* format, Args ... args) {
+    void writeFormatted(const char*, Args ...) {
     }
 
 };

--- a/include/ivi-logging.h
+++ b/include/ivi-logging.h
@@ -63,87 +63,87 @@ private:
 
 };
 
-#define log_with_context(_context_, severity, args ...) \
+#define log_with_context(_context_, severity, ...) \
 	for (auto dummy = &(_context_); (dummy != nullptr) && dummy->isEnabled(severity); dummy = nullptr) \
-		(_context_).createLog(severity, __FILE__, __LINE__, __PRETTY_FUNCTION__).write(args)
+		(_context_).createLog(severity, __FILE__, __LINE__, __PRETTY_FUNCTION__).write(__VA_ARGS__)
 
 #ifndef log_error
 
-#define log_with_severity(severity, args ...) log_with_context(getDefaultContext(), severity, ## args)
+#define log_with_severity(severity, ...) log_with_context(getDefaultContext(), severity, ## __VA_ARGS__)
 
 /**
  * Generate a log with "fatal" severity
  */
-#define log_fatal(args ...) log_with_context(getDefaultContext(), logging::LogLevel::Fatal, ## args)
+#define log_fatal(...) log_with_context(getDefaultContext(), logging::LogLevel::Fatal, ## __VA_ARGS__)
 
 /**
  * Generate a log with "error" severity
  */
-#define log_error(args ...) log_with_context(getDefaultContext(), logging::LogLevel::Error, ## args)
+#define log_error(...) log_with_context(getDefaultContext(), logging::LogLevel::Error, ## __VA_ARGS__)
 
 /**
  * Generate a log with "verbose" severity
  */
-#define log_verbose(args ...) log_with_context(getDefaultContext(), logging::LogLevel::Verbose, ## args)
+#define log_verbose(...) log_with_context(getDefaultContext(), logging::LogLevel::Verbose, ## __VA_ARGS__)
 
 /**
  * Generate a log with "info" severity
  */
-#define log_info(args ...) log_with_context(getDefaultContext(), logging::LogLevel::Info, ## args)
+#define log_info(...) log_with_context(getDefaultContext(), logging::LogLevel::Info, ## __VA_ARGS__)
 
 /**
  * Generate a log with "warning" severity
  */
-#define log_warn(args ...) log_with_context(getDefaultContext(), logging::LogLevel::Warning, ## args)
-#define log_warning(args ...) log_warn(args)
+#define log_warn(...) log_with_context(getDefaultContext(), logging::LogLevel::Warning, ## __VA_ARGS__)
+#define log_warning(...) log_warn(__VA_ARGS__)
 
 /**
  * Generate a log with "debug" severity
  */
-#define log_debug(args ...) log_with_context(getDefaultContext(), logging::LogLevel::Debug, ## args)
+#define log_debug(...) log_with_context(getDefaultContext(), logging::LogLevel::Debug, ## __VA_ARGS__)
 
 /**
  * Defines the identifiers of an application. This macro should be used at one place in every application.
  */
 #define LOG_DEFINE_APP_IDS(appID, appDescription) \
-	logging::AppLogContext s_appLogContext(appID, appDescription);
+	logging::AppLogContext s_appLogContext(appID, appDescription)
 
 /**
  * Create a LogContext with the given ID (4 characters in case of DLT support) and description
  */
 #define LOG_DECLARE_CONTEXT(contextName, contextShortID, contextDescription) LogContext contextName( \
 		contextShortID,	\
-		contextDescription);
+		contextDescription)
 
 /**
  * Create a new context and define is as default context for the current scope
  */
 #define LOG_DECLARE_DEFAULT_CONTEXT(context, contextID, contextDescription) \
 	LOG_DECLARE_CONTEXT(context, contextID, contextDescription); \
-	LOG_SET_DEFAULT_CONTEXT(context);
+	LOG_SET_DEFAULT_CONTEXT(context)
 
 /**
  * Import the given context, which should be exported by another module
  */
-#define LOG_IMPORT_CONTEXT(contextName) extern LogContext contextName;
+#define LOG_IMPORT_CONTEXT(contextName) extern LogContext contextName
 
 /**
  * Set the given context as default for the current scope
  */
 #define LOG_SET_DEFAULT_CONTEXT(context) static std::function<LogContext& ()> getDefaultContext = \
-	[] ()->LogContext & {return context; };
+	[] ()->LogContext & {return context; }
 
 /**
  * Import the given context and set it as default for the current scope
  */
 #define LOG_IMPORT_DEFAULT_CONTEXT(context) \
-		LOG_IMPORT_CONTEXT(context) \
+		LOG_IMPORT_CONTEXT(context); \
 		LOG_SET_DEFAULT_CONTEXT(context)
 
 /**
  * Set the given context as default for the current class
  */
-#define LOG_SET_CLASS_CONTEXT(context) static inline LogContext &getDefaultContext() {return context; }
+#define LOG_SET_CLASS_CONTEXT(context) static inline LogContext &getDefaultContext() { return context; }
 
 /**
  *

--- a/src/backtrace.cpp
+++ b/src/backtrace.cpp
@@ -16,7 +16,7 @@ std::string getStackTrace(unsigned int max_frames) {
 	ss << std::endl;
 
 	// storage array for stack trace address data
-	void* addrlist[max_frames + 1];
+	void **addrlist = new void*[max_frames + 1];
 
 	// retrieve current stack addresses
 	int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
@@ -83,6 +83,8 @@ std::string getStackTrace(unsigned int max_frames) {
 		free(symbollist);
 
 	}
+
+	delete [] addrlist;
 
 	return ss.str();
 

--- a/test/test_multithreaded.cpp
+++ b/test/test_multithreaded.cpp
@@ -6,7 +6,7 @@ typedef LogContextWithConsolePlusDLTIfAvailable LogContext;
 
 LOG_DECLARE_DEFAULT_CONTEXT(myTestContext, "TEST", "Test context");
 
-int main(int argc, const char** argv) {
+int main(int, const char**) {
 
 	new std::thread([&] () {
 				pthread_setname_np(pthread_self(), "MyThread2");


### PR DESCRIPTION
Warnings were about the following things:
* Named variadic macros (gcc extension)
* Superfluous semicolons after macros
* Unused argc and argv, and some other unused variables
* Variable-sized array in backtrace code

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>