### PR TITLE
Fix streaming operator << for unsigned long ints on 32-bit systems

### DIFF
--- a/include/ivi-logging-dlt.h
+++ b/include/ivi-logging-dlt.h
@@ -199,6 +199,10 @@ inline DltLogData& operator<<(DltLogData& data, long int v) {
 	dlt_user_log_write_int32(&data, v);
 	return data;
 }
+inline DltLogData& operator<<(DltLogData& data, unsigned long int v) {
+	dlt_user_log_write_uint32(&data, v);
+	return data;
+}
 #endif
 
 inline DltLogData& operator<<(DltLogData& data, double f) {

--- a/include/ivi-logging-null.h
+++ b/include/ivi-logging-null.h
@@ -82,6 +82,10 @@ inline NullLogData& operator<<(NullLogData& data, long int v) {
     UNUSED(v);
     return data;
 }
+inline NullLogData& operator<<(NullLogData& data, unsigned long int v) {
+    UNUSED(v);
+    return data;
+}
 #endif
 
 inline NullLogData& operator<<(NullLogData& data, double v) {


### PR DESCRIPTION
Need this for being able to do something like log_debug() << (unsigned long)10;